### PR TITLE
Display refreshed palettes after deleting from DOM

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -138,7 +138,7 @@ class App extends Component {
     e.preventDefault()
     deletePalette(paletteId)
     .then(networkMessage => this.setState({networkMessage}))
-    // .then(() => this.getAFoldersPalettes(folderId))
+    .then(() => this.getAFoldersPalettes(e, folderId))
     .catch(error => this.setState({error: 'Happy Little Accident Deleting Your Palette'}))
   }
 

--- a/src/apiCalls/apiCalls.js
+++ b/src/apiCalls/apiCalls.js
@@ -39,6 +39,7 @@ export const fetchAFolder = async folderId => {
 }
 
 export const fetchAFoldersPalettes = async folderId => {
+  console.log("We in here", folderId)
   try {
     const response = await fetch(process.env.REACT_APP_BACKEND_URL + `/api/v1/folders/${folderId}/palettes`)
     const data = await response.json()


### PR DESCRIPTION
Co-authored-by: Alyssa Lundgren <lundgrea@gmail.com>

#### What's this PR do?
This PR displays the remaining palettes on the DOM after one has been deleted from a given folder.
#### Where should the reviewer start?
The reviewer should start in the App.js file
#### How should this be manually tested?
This should be manually tested by going to localhost:3000, clicking on a folder with existing palettes, and watching to see if the palette disappears from the DOM.
#### What are the relevant tickets?
"A user should be able to delete a color palette."
