### PR TITLE
Complete toggleViewForms functionality

### DIFF
--- a/src/Components/PaletteForm/PaletteForm.css
+++ b/src/Components/PaletteForm/PaletteForm.css
@@ -6,6 +6,14 @@
   font-family: 'Caveat', cursive;
 }
 
+#initial-palette-container {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  width: 100%;
+  font-family: 'Caveat', cursive;
+}
+
 #palette-img {
   height: 50px;
   margin-right: 10px;
@@ -42,25 +50,55 @@
   font-size: 30px;
 }
 
-#dropdown-button {
-  background-color: #4CAF50;
-  color: white;
-  padding: 16px;
-  font-size: 16px;
-  border: none;
+#save-palette-forms-container {
+  width: 50%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-flow: row wrap;
+}
+
+#add-name-label-and-input {
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #FFF;
+  font-size: 30px;
+}
+
+#paletteName-input {
+  width: 70%;
+  border-radius: 5px;
+  height: 50px;
+  font-size: 20px;
+  padding: 5px;
+  margin-right: 10px;
 }
 
 #dropdown-container {
+  align-items: center;
   position: relative;
   display: inline-block;
+  width: 50%;
+}
+
+#dropdown-button {
+  background-color: #000;
+  color: white;
+  padding: 16px;
+  font-size: 30px;
+  border: none;
+  width: 70%;
+  border-radius: 5px;
+  margin-top: 15px;
 }
 
 #dropdown-folders {
   display: none;
   position: absolute;
   background-color: #f1f1f1;
-  min-width: 160px;
-  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  width: 100%;
   z-index: 1;
 }
 
@@ -75,4 +113,17 @@
 
 #dropdown-container:hover #dropdown-folders {display: block;}
 
-#dropdown-container:hover #dropdown-button {background-color: #3e8e41;}
+#dropdown-container:hover #dropdown-button {background-color: grey;}
+
+#submit-button-container {
+  width: 33%;
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
+}
+
+#submit-button {
+  width: 70%;
+  border-radius: 5px;
+  height: 50px;
+}

--- a/src/Components/PaletteForm/PaletteForm.js
+++ b/src/Components/PaletteForm/PaletteForm.js
@@ -7,6 +7,8 @@ class PaletteForm extends Component {
     this.state = {
       name: '',
       localFolderID: '',
+      isSaved: false,
+      viewForms: false,
       error: ''
     }
   }
@@ -35,8 +37,9 @@ class PaletteForm extends Component {
     })
   }
 
-  toggleSavePaletteInfo = () => {
-
+  toggleViewForms = () => {
+    console.log("oh hey")
+    this.setState({viewForms: !this.state.viewForms})
   }
 
   getFolderName = (e) => {
@@ -54,36 +57,47 @@ class PaletteForm extends Component {
   render() {
   return (
     <section className="PaletteForm">
+      {!this.state.viewForms ?
+      <div id="initial-palette-container">
       <article id="generatePalette-container">
-      <img id="palette-img"
-      src={require('../../assets/paint-palette-white.svg')} 
-      onClick={this.generateNewColors}
-      alt=""/>
-      <button id="generatePalette-button" onClick={this.generateNewColors}>Generate New Palette</button>
+        <img id="palette-img"
+        src={require('../../assets/paint-palette-white.svg')} 
+        onClick={this.generateNewColors}
+        alt=""/>
+        <button id="generatePalette-button" onClick={this.generateNewColors}>Generate New Palette</button>
       </article>
       <article id="savePalette-container">
-         <img id="download-img"
-        src={require('../../assets/download.svg')} 
-        alt=""/>
-        <button id="savePalette-button">Save Current Palette</button>
-        <form id="addNameSavePalette-container" hidden>
-        <label>Add Palette Name</label>
-          <input
-          id="paletteName-input"
-          placeholder="Palette Name..."
-          name="name"
-          value={this.state.name}
-          onChange={this.handleChange}
-          required/>
+        <div id="save-palette-buttons-container">
+          <img id="download-img" src={require('../../assets/download.svg')} alt="" onClick={this.toggleViewForms}/>
+          <button id="savePalette-button" onClick={this.toggleViewForms}>Save Current Palette</button> 
+        </div>
+      </article>
+      </div>
+      :
+        <form id="save-palette-forms-container">
+          <div id="add-name-label-and-input">
+            <label>Add Palette Name</label>
+            <input
+            id="paletteName-input"
+            placeholder="Palette Name..."
+            name="name"
+            value={this.state.name}
+            onChange={this.handleChange}
+            required/>
+          </div>
           <div id="dropdown-container">
-            <button id="dropdown-button">Save to Existing Folder</button>
+            <button id="dropdown-button">Pick Folder</button>
             <div id="dropdown-folders">
               {!this.props.isLoading && this.displayFolders()}
             </div>
           </div>
+          <div id="submit-button-container">
+            <button id="submit-button"
+            onClick={this.toggleViewForms}>Submit</button>
+          </div>
         </form>
-        </article> 
-    </section>
+      }
+      </section>
   )
 }
 


### PR DESCRIPTION
#### What's this PR do?
This PR initiates the functionality of toggling between showing and hiding the saved palette forms into view.
#### Where should the reviewer start?
The reviewer should start by clicking on the 'Save Palette' button, which should display the palette forms. Clicking submit should toggle back to the generate palette page.
#### How should this be manually tested?
This can be tested by clicking on the 'Save Palette' button, which should display the palette forms. Clicking submit should toggle back to the generate palette page.
#### What are the relevant tickets?
'toggle between user showing forms and not showing forms'
#### Screenshots (if appropriate)
#### Questions: